### PR TITLE
fix(api): Populate response for updateProject endpoint

### DIFF
--- a/backend/controllers/projectController.js
+++ b/backend/controllers/projectController.js
@@ -57,8 +57,17 @@ const updateProject = async (req, res) => {
     project.description = req.body.description || project.description;
     project.deadline = req.body.deadline || project.deadline;
 
-    const updatedProject = await project.save();
+    await project.save();
+
+    const populatedProject = await Project.findById(project._id)
+      .populate('owner', 'name email')
+      .populate('members', 'name email');
+
+    const updatedProject = populatedProject.toObject();
+    updatedProject.isOwner = true;
+
     res.json(updatedProject);
+    
   } catch (error) {
     res.status(500).json({ message: 'Server error while updating project' });
   }


### PR DESCRIPTION
The PUT /api/projects/:id endpoint returned an unpopulated project object, which was inconsistent with getProjectById. This caused UI bugs on the frontend after an edit.

This commit updates the `updateProject` controller to re-fetch, populate (`owner`, `members`), and add the `isOwner` flag to the project object before returning it.

This ensures the API response is consistent and resolves the UI bug on the frontend.

Fixes #31